### PR TITLE
グラフのクエリパラメータへの保存機能を修正&実装

### DIFF
--- a/GraphVisualizer/CodeChange.cs
+++ b/GraphVisualizer/CodeChange.cs
@@ -37,7 +37,8 @@ namespace GraphVisualizer
         {
             using (MemoryStream inputstream = new MemoryStream())
             { 
-                using(StreamWriter streamWriter = new StreamWriter(inputstream, System.Text.Encoding.UTF8))
+                var utf8WithoutBOM = new UTF8Encoding(false);//BOMを使用しないUTF8エンコーディングを使用
+                using (StreamWriter streamWriter = new StreamWriter(inputstream, utf8WithoutBOM))
                 {
                     await streamWriter.WriteAsync(code);
                     await streamWriter.FlushAsync();

--- a/GraphVisualizer/Pages/Graph.razor
+++ b/GraphVisualizer/Pages/Graph.razor
@@ -647,7 +647,7 @@
     public string? base64code { get; set; }
     [SupplyParameterFromQuery]
     [Parameter]
-    public string? node { get; set; }
+    public string? base64graph { get; set; }
     string url = "";
     string output = "";
     string sourceCode = "";
@@ -666,7 +666,7 @@
         string source = await CodeChange.CodeToParameter(sourceCode);
         string sss = await CodeChange.ParameterToCode(source);
 
-        url = baseurl + $"?base64code={source}&node={json}";
+        url = baseurl + $"?base64code={source}&base64graph={json}";
 
     }
     bool ControllerMenuVisible
@@ -983,10 +983,10 @@
                 sourceCode = Compiler.BaseCode;
             }
             bool direct = false;
-            if(node !=null){
+            if(base64graph !=null){
 
-                node = await CodeChange.ParameterToCode(node);
-                var data = JsonSerializer.Deserialize<JsonNodeEdge>(node,options);
+                base64graph = await CodeChange.ParameterToCode(base64graph);
+                var data = JsonSerializer.Deserialize<JsonNodeEdge>(base64graph,options);
                 direct = data.ToDirect;
 
                 data.Nodes.ForEach(x => Node.Create(x.id, x.color, x.title));

--- a/GraphVisualizer/Pages/Graph.razor
+++ b/GraphVisualizer/Pages/Graph.razor
@@ -644,10 +644,10 @@
 @code {
     [SupplyParameterFromQuery]
     [Parameter]
-    public string? base64code { get; set; }
+    public string? code { get; set; }
     [SupplyParameterFromQuery]
     [Parameter]
-    public string? base64graph { get; set; }
+    public string? graph { get; set; }
     string url = "";
     string output = "";
     string sourceCode = "";
@@ -666,7 +666,7 @@
         string source = await CodeChange.CodeToParameter(sourceCode);
         string sss = await CodeChange.ParameterToCode(source);
 
-        url = baseurl + $"?base64code={source}&base64graph={json}";
+        url = baseurl + $"?code={source}&graph={json}";
 
     }
     bool ControllerMenuVisible
@@ -966,11 +966,11 @@
 
             Compiler = new Compiler(ScriptService);
             IsInitialized = false;
-            if(base64code != null)
+            if(code != null)
             {
                 string code = "";
                 try{
-                    code = await CodeChange.ParameterToCode(base64code);
+                    code = await CodeChange.ParameterToCode(this.code);
 
                 }
                 catch(Exception e)
@@ -983,10 +983,10 @@
                 sourceCode = Compiler.BaseCode;
             }
             bool direct = false;
-            if(base64graph !=null){
+            if(graph !=null){
 
-                base64graph = await CodeChange.ParameterToCode(base64graph);
-                var data = JsonSerializer.Deserialize<JsonNodeEdge>(base64graph,options);
+                graph = await CodeChange.ParameterToCode(graph);
+                var data = JsonSerializer.Deserialize<JsonNodeEdge>(graph,options);
                 direct = data.ToDirect;
 
                 data.Nodes.ForEach(x => Node.Create(x.id, x.color, x.title));

--- a/GraphVisualizer/Pages/Graph.razor
+++ b/GraphVisualizer/Pages/Graph.razor
@@ -666,7 +666,7 @@
         string source = await CodeChange.CodeToParameter(sourceCode);
         string sss = await CodeChange.ParameterToCode(source);
 
-        url = baseurl + $"?base64code={source}";
+        url = baseurl + $"?base64code={source}&node={json}";
 
     }
     bool ControllerMenuVisible
@@ -998,7 +998,7 @@
 
                     if(node1 != null)
                     {
-                        node1.CreateToEdge(node2, int.Parse(x.weight));
+                        node1.CreateToEdge(node2, int.TryParse(x.weight, out int w) ? w : -1);//重みの設定がない場合(InternalEdge以外では-1として処理される？)、InternalEdgeのweightは空の文字列となるため、int.TryParseで判定する
                     }
                 });
             }


### PR DESCRIPTION
# BOM付きUTF-8エンコードによるJsonデシリアライザのエラーの修正
## 原因
グラフの情報を格納yするJsonのエンコード時にSystem.Text.UTF8ではBOM付きUTF-8が使用される。そのため、デコード時に先頭に残ったBOMがエラーを引き起こしていました。
## 修正点
UTF8Encodingを用いてBOM無しUTF-8エンコーディングを指定するように変更しました。

# 読み込み時にエラーが起きる問題。
## 原因
グラフのEdgeの情報をInternalEdgeから読み出す際に、重みの設定がない場合空の文字列がint.Parseに渡されエラーを引き起こしていました。
## 修正点
int.TryParseを用いて、重みの設定がない場合(weight内が空文字列)は-1をCreateToEdgeに渡すように変更しました。